### PR TITLE
Add content to PastResults page

### DIFF
--- a/src/components/PastResultsView/ResultsSummaryCard.tsx
+++ b/src/components/PastResultsView/ResultsSummaryCard.tsx
@@ -1,0 +1,95 @@
+import { Col, Row } from 'antd';
+import Paragraph from 'antd/es/typography/Paragraph';
+import Text from 'antd/es/typography/Text';
+import { Card } from 'components/ui/Card';
+import { Image } from 'components/ui/Image';
+
+import * as CXLModelResults from 'models/CXLModelResults';
+
+// Image license details here: https://commons.wikimedia.org/wiki/File:Standing_jaguar.jpg
+const PUBLIC_DOMAIN_PLACEHOLDER_IMAGE =
+  'https://upload.wikimedia.org/wikipedia/commons/0/0a/Standing_jaguar.jpg';
+
+type Props = {
+  modelRunMetadata: CXLModelResults.T;
+};
+
+function MetricDisplay({
+  metricName,
+  metricValue,
+}: {
+  metricName: string;
+  metricValue: string | number | Date;
+}): JSX.Element {
+  let formattedMetricValue = metricValue;
+  if (metricValue instanceof Date) {
+    formattedMetricValue = metricValue.toLocaleString('en-US');
+  }
+  // Typechecking for Paragraph expects a single child for some reason
+  return (
+    <Paragraph>
+      <>
+        <Text strong>{metricName}:</Text> {formattedMetricValue}
+      </>
+    </Paragraph>
+  );
+}
+
+function ModelRunMetadataSummary({ modelRunMetadata }: Props): JSX.Element {
+  const {
+    emptyimagecount,
+    imagecount,
+    imagedir,
+    modelname,
+    objectcount,
+    rundate,
+    runid,
+    resultsdir,
+  } = modelRunMetadata;
+  return (
+    <Card>
+      <MetricDisplay metricName="Model Name" metricValue={modelname} />
+      <MetricDisplay metricName="Run ID" metricValue={runid} />
+      <MetricDisplay metricName="Run Date" metricValue={rundate} />
+      <MetricDisplay metricName="Image Directory" metricValue={imagedir} />
+      <MetricDisplay metricName="Results Directory" metricValue={resultsdir} />
+      <MetricDisplay metricName="Image Count" metricValue={imagecount} />
+      <MetricDisplay
+        metricName="Empty Image Count"
+        metricValue={emptyimagecount}
+      />
+      <MetricDisplay metricName="Object Count" metricValue={objectcount} />
+    </Card>
+  );
+}
+
+function ModelRunImagePreview(): JSX.Element {
+  // TODO: Load images from user file system
+  const imageIds = [1, 2, 3, 4, 5, 6];
+  return (
+    <Row gutter={[16, 16]}>
+      {imageIds.map((imageId) => (
+        <Col span={8} key={imageId}>
+          <Image src={PUBLIC_DOMAIN_PLACEHOLDER_IMAGE} />
+        </Col>
+      ))}
+    </Row>
+  );
+}
+
+export function ResultsSummaryCard({ modelRunMetadata }: Props): JSX.Element {
+  const { rundate } = modelRunMetadata;
+
+  return (
+    <Card title={rundate.toLocaleDateString('en-US')}>
+      <Row gutter={[16, 16]}>
+        <Col span={12}>
+          <ModelRunMetadataSummary modelRunMetadata={modelRunMetadata} />
+        </Col>
+        <Col span={12}>
+          <ModelRunImagePreview />
+        </Col>
+      </Row>
+    </Card>
+  );
+}

--- a/src/components/PastResultsView/index.tsx
+++ b/src/components/PastResultsView/index.tsx
@@ -1,23 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { Card } from 'components/ui/Card';
-
-import * as CXLModelResults from 'models/CXLModelResults';
+import { ResultsSummaryCard } from './ResultsSummaryCard';
 
 const READ_PAST_RESULTS_QUERY = ['allPastResults'];
-
-type SummaryCardProps = {
-  modelRunMetadata: CXLModelResults.T;
-};
-function ResultsSummaryCard({
-  modelRunMetadata,
-}: SummaryCardProps): JSX.Element {
-  const { rundate } = modelRunMetadata;
-  return (
-    <Card title={rundate.toLocaleDateString('en-US')}>
-      Results summary card
-    </Card>
-  );
-}
 
 export function PastResultsView(): JSX.Element {
   // read results written by the python script

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -39,7 +39,7 @@ type Props = {
 };
 
 /**
- * A Button component. This is a thin wrapper around the And Design Button
+ * A Button component. This is a thin wrapper around the Ant Design Button
  * component.
  */
 export function Button(props: Props): JSX.Element {

--- a/src/components/ui/Card/index.tsx
+++ b/src/components/ui/Card/index.tsx
@@ -7,7 +7,7 @@ type Props = {
 };
 
 /**
- * A Card component. This is a thin wrapper around the And Design Card
+ * A Card component. This is a thin wrapper around the Ant Design Card
  * component.
  */
 export function Card({ children, title }: Props): JSX.Element {

--- a/src/components/ui/FileInput/index.tsx
+++ b/src/components/ui/FileInput/index.tsx
@@ -28,7 +28,7 @@ function dummyRequest({ onSuccess }: UploadRequestOption): void {
 }
 
 /**
- * A File Input component. This is a thin wrapper around the And Design Upload
+ * A File Input component. This is a thin wrapper around the Ant Design Upload
  * component, except we aren't using this to upload anything. This component is
  * used only as a file or folder picker.
  *

--- a/src/components/ui/Heading/index.tsx
+++ b/src/components/ui/Heading/index.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 /**
- * A Heading component. This is a thin wrapper around the And Design Title
+ * A Heading component. This is a thin wrapper around the Ant Design Title
  * component.
  */
 export function Heading({ children, level = 1 }: Props): JSX.Element {

--- a/src/components/ui/Image/index.tsx
+++ b/src/components/ui/Image/index.tsx
@@ -1,0 +1,13 @@
+import { Image as AntImage } from 'antd';
+
+type Props = {
+  src: string;
+};
+
+/**
+ * A Image component. This is a thin wrapper around the Ant Design Image
+ * component.
+ */
+export function Image({ src }: Props): JSX.Element {
+  return <AntImage src={src} />;
+}


### PR DESCRIPTION
Additional content and layout template for the PastResults page, using placeholder data. 

<img width="1413" alt="Screen Shot 2023-03-10 at 4 32 11 PM" src="https://user-images.githubusercontent.com/125505542/224433574-89e8bcac-bbcf-490e-b522-86f0edee19e9.png">

Stacked on https://github.com/cxl-garage/desktop-app-sentinel/pull/7 (not used to stacked MRs on github, is there a better way to do this?).

