### PR TITLE
PastResults: Load images by directory path

### DIFF
--- a/src/components/PastResultsView/ResultsSummaryCard.tsx
+++ b/src/components/PastResultsView/ResultsSummaryCard.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Col, Input, Row } from 'antd';
 import Paragraph from 'antd/es/typography/Paragraph';
 import Text from 'antd/es/typography/Text';
@@ -64,21 +65,60 @@ function ModelRunMetadataSummary({ modelRunMetadata }: Props): JSX.Element {
   );
 }
 
-function ModelRunImagePreview({
-  localPath,
-}: {
-  localPath?: string;
-}): JSX.Element {
-  const imageIds = [1, 2, 3, 4, 5, 6];
+function ImageGrid({ filePaths }: { filePaths: string[] }): JSX.Element {
   return (
     <Row gutter={[16, 16]}>
-      {imageIds.map((imageId) => (
-        <Col span={8} key={imageId}>
-          <Image src={localPath || PUBLIC_DOMAIN_PLACEHOLDER_IMAGE} />
+      {filePaths.map((imageFilePath) => (
+        <Col span={8} key={imageFilePath}>
+          <Image src={imageFilePath} />
         </Col>
       ))}
     </Row>
   );
+}
+
+function ModelRunImagePreviewPlaceholder(): JSX.Element {
+  const imageFilePaths = Array.from(
+    { length: 6 },
+    (_value, index: number) =>
+      `${PUBLIC_DOMAIN_PLACEHOLDER_IMAGE}?index=${index}`,
+  );
+  return <ImageGrid filePaths={imageFilePaths} />;
+}
+
+function ModelRunImagePreview({
+  localPath,
+}: {
+  localPath: string;
+}): JSX.Element {
+  const {
+    data: files,
+    isError,
+    error,
+  } = useQuery({
+    queryFn: () => window.SentinelDesktopService.getFilesInDir(localPath),
+    queryKey: ['fetchDir', localPath],
+  });
+  if (isError) {
+    return (
+      <Paragraph>
+        <>Error loading images: {(error as Error).message}</>
+      </Paragraph>
+    );
+  }
+  if (!files) {
+    return <div>Loading...</div>;
+  }
+
+  const imageFilePaths: string[] = files
+    .filter(
+      (file: string) =>
+        file.endsWith('.jpg') ||
+        file.endsWith('.png') ||
+        file.endsWith('.jpeg'),
+    )
+    .map((file: string) => `localfile://${file}`);
+  return <ImageGrid filePaths={imageFilePaths.slice(0, 6)} />;
 }
 
 export function ResultsSummaryCard({ modelRunMetadata }: Props): JSX.Element {
@@ -93,7 +133,6 @@ export function ResultsSummaryCard({ modelRunMetadata }: Props): JSX.Element {
 
   return (
     <Card title={rundate.toLocaleDateString('en-US')}>
-      {/* Temporary local path loader until we have paginated directory filename endpoint */}
       <Input
         placeholder="Proof-of-concept local path loader"
         onChange={handlePathInput}
@@ -103,9 +142,11 @@ export function ResultsSummaryCard({ modelRunMetadata }: Props): JSX.Element {
           <ModelRunMetadataSummary modelRunMetadata={modelRunMetadata} />
         </Col>
         <Col span={12}>
-          <ModelRunImagePreview
-            localPath={localPath ? `localfile:////${localPath}` : ''}
-          />
+          {localPath ? (
+            <ModelRunImagePreview localPath={localPath} />
+          ) : (
+            <ModelRunImagePreviewPlaceholder />
+          )}
         </Col>
       </Row>
     </Card>

--- a/src/main/SentinelDesktopService/ISentinelDesktopService.ts
+++ b/src/main/SentinelDesktopService/ISentinelDesktopService.ts
@@ -4,4 +4,5 @@ import * as CXLModelResults from 'models/CXLModelResults';
 export interface ISentinelDesktopService {
   getAllLogRecords(): Promise<LogRecord.T[]>;
   getAllCXLModelResults(): Promise<CXLModelResults.T[]>;
+  getFilesInDir: (dirPath: string) => Promise<string[]>;
 }

--- a/src/main/SentinelDesktopService/index.ts
+++ b/src/main/SentinelDesktopService/index.ts
@@ -83,6 +83,19 @@ class SentinelDesktopServiceImpl implements ISentinelDesktopService {
       );
     });
   }
+
+  getFilesInDir(dirPath: string): Promise<string[]> {
+    return new Promise((resolve, reject) => {
+      fs.readdir(dirPath, (err: unknown, files: string[]) => {
+        if (err) {
+          reject(new Error(`Unable to read directory: ${dirPath}`));
+        } else {
+          // Return full paths
+          resolve(files.map((file) => path.join(dirPath, file)));
+        }
+      });
+    });
+  }
 }
 
 export const SentinelDesktopService = new SentinelDesktopServiceImpl();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -46,6 +46,16 @@ ipcMain.handle(
   },
 );
 
+ipcMain.handle(
+  'api/files/getDir',
+  async (_event, dirPath: string): Promise<string[]> => {
+    // eslint-disable-next-line no-console
+    console.log('Calling api/files/getDir');
+    // TODO: Handle exceptions cleanly somehow, pass custom errors to client
+    return SentinelDesktopService.getFilesInDir(dirPath);
+  },
+);
+
 // below 2 functions handle openning and selecting a new directory, using electron's dialog.showOpenDialog
 // used in afterorg.tsx to select folder to get images from and folder to download images to
 
@@ -376,11 +386,16 @@ async function setupApp(): Promise<void> {
     // Out-of-box file:// protocol gets "Not allowed to load local resource" error
     // https://www.electronjs.org/docs/latest/api/protocol#protocolregisterfileprotocolscheme-handler
     protocol.registerFileProtocol('localfile', (request, callback) => {
-      const filePath = urllib.fileURLToPath(
-        `file://${request.url.slice('localfile://'.length)}`,
-      );
-      // eslint-disable-next-line promise/no-callback-in-promise
-      callback(filePath);
+      try {
+        const filePath = urllib.fileURLToPath(
+          `file://${request.url.slice('localfile://'.length)}`,
+        );
+        // eslint-disable-next-line promise/no-callback-in-promise
+        callback(filePath);
+      } catch (error) {
+        // TODO: handle error
+        console.error(error);
+      }
     });
   });
   createWindow();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -18,6 +18,8 @@ const SentinelDesktopServiceBridge = {
   getAllLogRecords: async () => ipcRenderer.invoke('api/logs/getAll'),
   getAllCXLModelResults: async () =>
     ipcRenderer.invoke('api/cxl-model-results/getAll'),
+  getFilesInDir: async (dirPath: string) =>
+    ipcRenderer.invoke('api/files/getDir', dirPath),
 
   // Legacy functions.
   // TODO: These should be either refactored or removed.

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -8,6 +8,7 @@ declare global {
     SentinelDesktopService: {
       getAllLogRecords: () => Promise<LogRecord.T[]>;
       getAllCXLModelResults: () => Promise<CXLModelResults.T[]>;
+      getFilesInDir: (dirPath: string) => Promise<string[]>;
 
       // deprecated functions (need refactoring)
       findOrgModels: (arg: any) => Promise<any>;


### PR DESCRIPTION
Sets up a new ipc endpoint for fetching list of files within a user directory. Slightly improved error handling over previous, but still pretty ugly; hoping to improve error handling more over time.


<img width="1137" alt="Screen Shot 2023-03-17 at 1 57 50 PM" src="https://user-images.githubusercontent.com/125505542/225992762-9d0e0b40-1b8b-4cb5-a23d-0b84ea878739.png">
<img width="1140" alt="Screen Shot 2023-03-17 at 1 58 18 PM" src="https://user-images.githubusercontent.com/125505542/225992767-3aa4edec-dbeb-431e-ac9b-9219cf2453e4.png">
