### PR TITLE
Improve styling of past results page

### DIFF
--- a/src/components/PastResultsView/ImagePreviews.tsx
+++ b/src/components/PastResultsView/ImagePreviews.tsx
@@ -6,11 +6,19 @@ import { Image } from 'components/ui/Image';
 const PUBLIC_DOMAIN_PLACEHOLDER_IMAGE =
   'https://upload.wikimedia.org/wikipedia/commons/0/0a/Standing_jaguar.jpg';
 
-export function ImageGrid({ filePaths }: { filePaths: string[] }): JSX.Element {
+export function ImageGrid({
+  filePaths,
+  imagesPerRow,
+}: {
+  filePaths: string[];
+  imagesPerRow?: number;
+}): JSX.Element {
+  // Grid width is 24 cells, define span to get desired row width
+  const span = Math.round(24 / (imagesPerRow ?? 3));
   return (
     <Row gutter={16}>
       {filePaths.map((imageFilePath) => (
-        <Col span={8} key={imageFilePath}>
+        <Col span={span} key={imageFilePath}>
           <Image src={imageFilePath} />
         </Col>
       ))}
@@ -20,23 +28,27 @@ export function ImageGrid({ filePaths }: { filePaths: string[] }): JSX.Element {
 
 export function ModelRunImagePreviewPlaceholder({
   count,
+  imagesPerRow,
 }: {
   count: number;
+  imagesPerRow?: number;
 }): JSX.Element {
   const imageFilePaths = Array.from(
     { length: count },
     (_value, index: number) =>
       `${PUBLIC_DOMAIN_PLACEHOLDER_IMAGE}?index=${index}`,
   );
-  return <ImageGrid filePaths={imageFilePaths} />;
+  return <ImageGrid filePaths={imageFilePaths} imagesPerRow={imagesPerRow} />;
 }
 
 export function ModelRunImagePreview({
   localPath,
   count,
+  imagesPerRow,
 }: {
   localPath: string;
   count?: number;
+  imagesPerRow?: number;
 }): JSX.Element {
   const {
     data: files,
@@ -67,5 +79,10 @@ export function ModelRunImagePreview({
         file.endsWith('.jpeg'),
     )
     .map((file: string) => `localfile://${file}`);
-  return <ImageGrid filePaths={imageFilePaths.slice(0, count)} />;
+  return (
+    <ImageGrid
+      filePaths={imageFilePaths.slice(0, count)}
+      imagesPerRow={imagesPerRow}
+    />
+  );
 }

--- a/src/components/PastResultsView/ModelRunMetadataSummary.tsx
+++ b/src/components/PastResultsView/ModelRunMetadataSummary.tsx
@@ -1,5 +1,4 @@
-import { Card, Col, Row } from 'antd';
-import Paragraph from 'antd/es/typography/Paragraph';
+import { Card, Col, Row, Space, Tag } from 'antd';
 import Text from 'antd/es/typography/Text';
 
 import * as CXLModelResults from 'models/CXLModelResults';
@@ -21,44 +20,68 @@ function MetricDisplay({
   if (metricValue instanceof Date) {
     formattedMetricValue = metricValue.toLocaleString('en-US');
   }
-  // Typechecking for Paragraph expects a single child for some reason
   return (
-    <Paragraph>
-      <>
+    <Row gutter={16}>
+      <Col span={12}>
         <Title level={5} type="secondary">
           {metricName}
         </Title>{' '}
+      </Col>
+      <Col span={12}>
         <Text>{String(formattedMetricValue)}</Text>
-      </>
-    </Paragraph>
+      </Col>
+    </Row>
   );
 }
 
 function MetricDisplayCard({
   metricName,
   metricValue,
+  highlightText,
 }: {
   metricName: string;
   metricValue: string | number | Date;
+  highlightText?: string;
 }): JSX.Element {
   let formattedMetricValue = metricValue;
   if (metricValue instanceof Date) {
     formattedMetricValue = metricValue.toLocaleString('en-US');
   }
   return (
-    <CardShadowWrapper>
-      <Card>
-        <div className="h-18 text-black">
-          <Row gutter={[16, 8]}>
-            <Text>{metricName}</Text>
+    <CardShadowWrapper className="h-28">
+      <Card
+        bodyStyle={{ padding: '10px', height: '100%' }}
+        style={{ height: '100%' }}
+      >
+        <Row>
+          <Text>{metricName}</Text>
+        </Row>
+        <Row className="maxh-3">
+          <Col flex="auto" className="h-10 text-right">
+            <Title level={1}>{String(formattedMetricValue)}</Title>
+          </Col>
+        </Row>
+        {highlightText && (
+          <Row className="mt-1">
+            <Col flex="auto" className="mx-0 text-right">
+              <Tag color="blue" className="mx-0" style={{ margin: '0px' }}>
+                {highlightText}
+              </Tag>
+            </Col>
           </Row>
-          <Row gutter={[16, 8]}>
-            <Title level={3}>{String(formattedMetricValue)}</Title>
-          </Row>
-        </div>
+        )}
       </Card>
     </CardShadowWrapper>
   );
+}
+
+function toPercentageStr(
+  numerator: number,
+  denominator: number,
+): string | undefined {
+  return denominator > 0
+    ? `${((numerator / denominator) * 100).toFixed(2)}%`
+    : undefined;
 }
 
 export function ModelRunMetadataSummary({
@@ -74,7 +97,7 @@ export function ModelRunMetadataSummary({
   } = modelRunMetadata;
   return (
     <>
-      <Row gutter={[16, 16]}>
+      <Row gutter={[16, 0]}>
         <Col span={8}>
           <MetricDisplayCard
             metricName="Images processed"
@@ -85,23 +108,30 @@ export function ModelRunMetadataSummary({
           <MetricDisplayCard
             metricName="Empty images"
             metricValue={emptyimagecount}
+            highlightText={toPercentageStr(objectcount, imagecount)}
           />
         </Col>
         <Col span={8}>
           <MetricDisplayCard
             metricName="Objects found"
             metricValue={objectcount}
+            highlightText={toPercentageStr(objectcount, imagecount)}
           />
         </Col>
       </Row>
-      <Row gutter={[16, 16]}>
+      <Row gutter={16} className="mt-4">
         <Col span={24}>
-          <MetricDisplay metricName="Model name" metricValue={modelname} />
-          <MetricDisplay
-            metricName="Saved to folder"
-            metricValue={resultsdir}
-          />
-          <MetricDisplay metricName="Images in folder" metricValue={imagedir} />
+          <Space direction="vertical">
+            <MetricDisplay metricName="Model name" metricValue={modelname} />
+            <MetricDisplay
+              metricName="Saved to folder"
+              metricValue={resultsdir}
+            />
+            <MetricDisplay
+              metricName="Images in folder"
+              metricValue={imagedir}
+            />
+          </Space>
         </Col>
       </Row>
     </>

--- a/src/components/PastResultsView/PastResultsAllPictures.tsx
+++ b/src/components/PastResultsView/PastResultsAllPictures.tsx
@@ -1,9 +1,7 @@
 import { Col, Row, Space } from 'antd';
 import { LeftOutlined } from '@ant-design/icons';
-import { Card } from 'components/ui/Card';
 import { useNavigate, useParams } from 'react-router-dom';
 import { PUBLIC_DOMAIN_PLACEHOLDER_IMAGE } from 'components/RunModelView/tempMockData';
-import { CardShadowWrapper } from './PastResultsViewStyledComponents';
 import { Button } from '../ui/Button';
 import {
   ModelRunImagePreview,
@@ -17,24 +15,26 @@ export function PastResultsAllPictures(): JSX.Element {
   const navigate = useNavigate();
 
   return (
-    <CardShadowWrapper className="mb-1 mt-2.5">
-      <Card>
-        <Space direction="vertical" size="middle">
-          <Button icon={<LeftOutlined />} onClick={() => navigate(URL)}>
-            Back
-          </Button>
-          <Row gutter={16}>
-            <Col span={24}>
-              {resultsPath &&
-              resultsPath !== PUBLIC_DOMAIN_PLACEHOLDER_IMAGE ? (
-                <ModelRunImagePreview localPath={resultsPath} />
-              ) : (
-                <ModelRunImagePreviewPlaceholder count={20} />
-              )}
-            </Col>
-          </Row>
-        </Space>
-      </Card>
-    </CardShadowWrapper>
+    <Space direction="vertical" size="middle" className="mx-8 my-4">
+      {/* Vertical alignment needed becase icon by default
+              sits too low and looks awkward visually. */}
+      <Button
+        size="large"
+        icon={<LeftOutlined className="align-[1px]" />}
+        onClick={() => navigate(URL)}
+        type="text"
+      >
+        Back
+      </Button>
+      <Row gutter={16}>
+        <Col span={24}>
+          {resultsPath && resultsPath !== PUBLIC_DOMAIN_PLACEHOLDER_IMAGE ? (
+            <ModelRunImagePreview localPath={resultsPath} imagesPerRow={4} />
+          ) : (
+            <ModelRunImagePreviewPlaceholder count={20} imagesPerRow={4} />
+          )}
+        </Col>
+      </Row>
+    </Space>
   );
 }

--- a/src/components/PastResultsView/ResultsSummaryCard.tsx
+++ b/src/components/PastResultsView/ResultsSummaryCard.tsx
@@ -2,7 +2,6 @@ import { Col, Row } from 'antd';
 import { Card } from 'components/ui/Card';
 
 import * as CXLModelResults from 'models/CXLModelResults';
-import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { PUBLIC_DOMAIN_PLACEHOLDER_IMAGE } from 'components/RunModelView/tempMockData';
 import { ModelRunMetadataSummary } from './ModelRunMetadataSummary';
@@ -18,11 +17,6 @@ type Props = {
   imagePathOverride?: string;
 };
 
-const MainResultCardWrapper = styled(CardShadowWrapper)`
-  margin-top: 10px;
-  margin-bottom: 5px;
-`;
-
 export function ResultsSummaryCard({
   modelRunMetadata,
   imagePathOverride,
@@ -36,24 +30,30 @@ export function ResultsSummaryCard({
   const { rundate } = modelRunMetadata;
 
   return (
-    <MainResultCardWrapper>
+    <CardShadowWrapper className="my-4">
       <Card title={rundate.toLocaleDateString('en-US')}>
         <Row gutter={16}>
           <Col span={12}>
             <ModelRunMetadataSummary modelRunMetadata={modelRunMetadata} />
           </Col>
           <Col span={12}>
-            <>
+            <Row>
               {imagePathOverride ? (
                 <ModelRunImagePreview localPath={imagePathOverride} count={6} />
               ) : (
                 <ModelRunImagePreviewPlaceholder count={6} />
               )}
-              <Button onClick={() => navigate(url)}>View all images</Button>
-            </>
+            </Row>
+            <Row>
+              <div className="ml-auto">
+                <Button size="large" type="text" onClick={() => navigate(url)}>
+                  View all images
+                </Button>
+              </div>
+            </Row>
           </Col>
         </Row>
       </Card>
-    </MainResultCardWrapper>
+    </CardShadowWrapper>
   );
 }

--- a/src/components/PastResultsView/index.tsx
+++ b/src/components/PastResultsView/index.tsx
@@ -11,8 +11,6 @@ export function PastResultsView(): JSX.Element {
     queryFn: window.SentinelDesktopService.getAllCXLModelResults,
     queryKey: READ_PAST_RESULTS_QUERY,
   });
-  console.log('Past results loaded', pastResults);
-
   const [localPath, setLocalPath] = React.useState('');
 
   const handlePathInput = (
@@ -25,11 +23,12 @@ export function PastResultsView(): JSX.Element {
     return <div>Loading...</div>;
   }
   return (
-    <Row gutter={[16, 16]}>
+    <Row gutter={[16, 16]} className="my-4">
       <Col span={22} offset={1}>
         <Input
-          placeholder="Proof-of-concept local path loader"
+          placeholder="Search results... (currently: proof-of-concept local path loader)"
           onChange={handlePathInput}
+          className="max-w-lg"
         />
         {pastResults?.map((modelRunMetadata) => (
           <ResultsSummaryCard

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -29,6 +29,8 @@ type Props = {
   /** Triggered when this button is clicked. */
   onClick?: React.MouseEventHandler<HTMLAnchorElement | HTMLButtonElement>;
 
+  size?: 'large' | 'middle' | 'small';
+
   /**
    * The target for an anchor button. Only used if the button type is 'link'.
    */


### PR DESCRIPTION
Various styling tweaks added to bring closer to the figma mocks.

<img width="1282" alt="Screen Shot 2023-04-30 at 3 07 06 PM" src="https://user-images.githubusercontent.com/125505542/235455382-ba7e12a4-c4ee-4409-927b-959f41a02845.png">
<img width="1278" alt="Screen Shot 2023-04-30 at 3 07 15 PM" src="https://user-images.githubusercontent.com/125505542/235455389-7f531e2f-d835-42b8-8e32-5e9be5e4d4f7.png">
