### PR TITLE
Use PaginatedImageGrid for PastResults [1/n]

### DIFF
--- a/src/components/PastResultsView/PastResultsAllPictures.tsx
+++ b/src/components/PastResultsView/PastResultsAllPictures.tsx
@@ -19,7 +19,7 @@ export function PastResultsAllPictures(): JSX.Element {
   });
 
   return (
-    <Space direction="vertical" size="middle" className="mx-8 my-4">
+    <Space direction="vertical" size="middle" className="w-full px-8 py-4">
       <Button
         size="large"
         icon={<LeftOutlined />}


### PR DESCRIPTION
Some additional styling tweaks needed for the search results page.

Also note in the video some weird behaviour with the image tile size, haven't investigated too closely yet.

Video before css fix:
https://github.com/cxl-garage/desktop-app-sentinel/assets/125505542/4a669ad9-7fae-499c-a0ab-d3afdb9ffd99

Current styling:
<img width="1419" alt="Screen Shot 2023-06-21 at 5 12 10 PM" src="https://github.com/cxl-garage/desktop-app-sentinel/assets/125505542/f1dfd4bb-8e74-469d-916d-26b6b12de137">

