### PR TITLE
Improve prisma timeout behaviour

### DIFF
--- a/.env
+++ b/.env
@@ -4,4 +4,5 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="file:./dev.db"
+# connection_limit follows recommendation in https://github.com/prisma/prisma/issues/2955
+DATABASE_URL="file:./dev.db?connection_limit=1&socket_timeout=5"


### PR DESCRIPTION
When investigating hanging job completion issue
<img width="1223" alt="Screen Shot 2023-07-15 at 3 14 37 PM" src="https://github.com/cxl-garage/desktop-app-sentinel/assets/125505542/c15a90d9-226a-43d9-96f0-5dc5c04da226">
I noticed in the logs
<img width="939" alt="Screen Shot 2023-07-15 at 3 18 33 PM" src="https://github.com/cxl-garage/desktop-app-sentinel/assets/125505542/31e55289-b3c4-47ad-87c4-5195913e41bf">

This MR adds retry handling in the runner code which then leads to this behaviour (fixing the hanging completion bug):
<img width="942" alt="Screen Shot 2023-07-15 at 4 04 28 PM" src="https://github.com/cxl-garage/desktop-app-sentinel/assets/125505542/1d78d9e3-1050-4552-9b67-880ba98cbf9b">

This MR also adjusts the DB connection settings using `?connection_limit=1&socket_timeout=5` based on the issue here: https://www.github.com/prisma/prisma/issues/2955 - this should provide better safety for all the queries in the app. I don't notice any impacts to performance. With this change the connection timeout no long occurs whatsoever, as far as I can tell.
