### PR TITLE
Fix nesting output directories

### DIFF
--- a/src/components/RunModelView/RunModelInputs/RunModelInputs.tsx
+++ b/src/components/RunModelView/RunModelInputs/RunModelInputs.tsx
@@ -62,7 +62,6 @@ function RunModelInputs(): JSX.Element {
         Math.floor(currentModelRun.confidenceThreshold * 100),
       );
       setValue('inputDirectory', currentModelRun.inputPath);
-      setValue('outputDirectory', currentModelRun.outputPath);
     }
   }, [currentModelRun, setValue]);
 


### PR DESCRIPTION
I'm not sure why we reassign all the inputs using the model run values, @anglee maybe you have more context? This proposed fix will just not overwrite the input with the date-stamped output directory. 

Sidenote: when committing changes to RunModelInputs.tsx , I get a circular dependency error that seems to be caused by `import { Control } from 'react-hook-form/dist/types';` - for now I have skipped validation on the commit but we should fix this in future.